### PR TITLE
[FEATURE] AccessTokenWrapper::FromRecord module.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.0 (2018-01-03)
+- [FEATURE] Adds in AccessTokenWrapper::FromRecord as a completely new tactic for wrapping API calls.
+
 ## 0.2.0 (2018-01-02)
 - [FEATURE] The library now checks the expires_at date of the token before attempting an API call.
 - [BREAKING] The refresh callback now only optionally contains an exception, when an exception is raised, if the refresh is due to the expires_at field (which should be the majority of the time) it will be `nil`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,6 @@
+## 0.2.0 (2018-01-02)
+- [FEATURE] The library now checks the expires_at date of the token before attempting an API call.
+- [BREAKING] The refresh callback now only optionally contains an exception, when an exception is raised, if the refresh is due to the expires_at field (which should be the majority of the time) it will be `nil`
+
 ## 0.1.0 (2017-09-20)
 - [BREAKING] `AccessTokenWrapper::Base#token` was renamed to `#raw_token`.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,8 +7,13 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
+    hashdiff (0.3.7)
     jwt (1.5.6)
     multi_json (1.12.2)
     multi_xml (0.6.0)
@@ -19,8 +24,14 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
+    public_suffix (3.0.1)
     rack (2.0.3)
     rake (12.3.0)
+    safe_yaml (1.0.4)
+    webmock (3.1.1)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
 
 PLATFORMS
   ruby
@@ -29,6 +40,7 @@ DEPENDENCIES
   access_token_wrapper!
   bundler (~> 1.3)
   rake
+  webmock
 
 BUNDLED WITH
    1.16.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,34 @@
+PATH
+  remote: .
+  specs:
+    access_token_wrapper (0.2.0)
+      oauth2
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    faraday (0.12.2)
+      multipart-post (>= 1.2, < 3)
+    jwt (1.5.6)
+    multi_json (1.12.2)
+    multi_xml (0.6.0)
+    multipart-post (2.0.0)
+    oauth2 (1.4.0)
+      faraday (>= 0.8, < 0.13)
+      jwt (~> 1.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 3)
+    rack (2.0.3)
+    rake (12.3.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  access_token_wrapper!
+  bundler (~> 1.3)
+  rake
+
+BUNDLED WITH
+   1.16.1

--- a/access_token_wrapper.gemspec
+++ b/access_token_wrapper.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "oauth2"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "webmock"
 end

--- a/lib/access_token_wrapper.rb
+++ b/lib/access_token_wrapper.rb
@@ -1,1 +1,2 @@
 require "access_token_wrapper/base"
+require "access_token_wrapper/from_record"

--- a/lib/access_token_wrapper/base.rb
+++ b/lib/access_token_wrapper/base.rb
@@ -4,10 +4,26 @@ module AccessTokenWrapper
     EXPIRY_GRACE_SEC = 30
     attr_reader :raw_token
 
+    # This is the core functionality
+    #
+    # @example
+    #   AccessTokenWrapper::Base.new(token) do |new_token, exception|
+    #     update_user_from_access_token(new_token)
+    #   end
+    #
+    # @param [<OAuth2::AccessToken] raw_token An instance of an OAuth2::AccessToken object
+    # @param [&block] callback A callback that gets called when a token is refreshed,
+    #  the callback is provided `new_token` and optional `exception` parameters
+    #
+    # @return <AccessTokenWrapper::Base>
+    #
+    # @api public
     def initialize(raw_token, &callback)
       @raw_token = raw_token
       @callback  = callback
     end
+
+  private
 
     def method_missing(method_name, *args, &block)
       refresh_token! if token_expiring?

--- a/lib/access_token_wrapper/base.rb
+++ b/lib/access_token_wrapper/base.rb
@@ -1,6 +1,7 @@
 module AccessTokenWrapper
   class Base
     NON_ERROR_CODES = [402, 404, 422, 414, 429, 500, 503]
+    EXPIRY_GRACE_SEC = 30
     attr_reader :raw_token
 
     def initialize(raw_token, &callback)
@@ -9,6 +10,7 @@ module AccessTokenWrapper
     end
 
     def method_missing(method_name, *args, &block)
+      refresh_token! if token_expiring?
       @raw_token.send(method_name, *args, &block)
     rescue OAuth2::Error => exception
       if NON_ERROR_CODES.include?(exception.response.status)
@@ -19,9 +21,13 @@ module AccessTokenWrapper
       end
     end
 
-    def refresh_token!(exception)
+    def refresh_token!(exception = nil)
       @raw_token = @raw_token.refresh!
       @callback.call(@raw_token, exception)
+    end
+
+    def token_expiring?
+      @raw_token.expires_at < (Time.now.to_i + EXPIRY_GRACE_SEC)
     end
 
     def respond_to_missing?(method_name, include_private = false)

--- a/lib/access_token_wrapper/from_record.rb
+++ b/lib/access_token_wrapper/from_record.rb
@@ -1,0 +1,82 @@
+module AccessTokenWrapper
+  class FromRecord < Base
+    attr_reader :record
+
+    # This is the core functionality
+    #
+    # @example
+    #   AccessTokenWrapper::FromRecord.new(client: client, record: user, lock: :redis) do |new_token, exception|
+    #     update_user_from_access_token(new_token)
+    #   end
+    #
+    # @param [<OAuth2::Client>] client An instance of an OAuth2::Client object
+    # @param [<Object>] record An object that responds to `access_token`,
+    #   `refresh_token`, `expires_at`, `id` and `reload` (Likely an ActiveRecord model)
+    # @param [#lock] lock Optional, if provided either the symbol `:redis` to use the
+    #   built-in Redis lock or any other object that responds to a method named `lock`
+    #   and takes block that yields.
+    # @param [&block] callback A callback that gets called when a token is refreshed,
+    #   the callback is provided `new_token` and optional `exception` parameters
+    #
+    # @return <AccessTokenWrapper::FromRecord>
+    #
+    # @api public
+    def initialize(client:, record:, lock: nil, &callback)
+      @oauth_client = client
+      @record       = record
+      @lock         = determine_lock(lock)
+      super(build_token, &callback)
+    end
+
+  private
+
+    # Override the refresh_token! method from the Base class to add all the extra functionality
+    def refresh_token!(exception = nil)
+      @lock.lock do
+        fetch_fresh_record
+
+        if !token_changed?
+          @raw_token = @raw_token.refresh!
+          # TODO: We may need this for https://github.com/doorkeeper-gem/doorkeeper/pull/769
+          # @raw_token.get('/users/current')
+        end
+        @callback.call(@raw_token, exception)
+      end
+    end
+
+    def build_token
+      OAuth2::AccessToken.new(@oauth_client,  record.access_token, {
+        refresh_token: record.refresh_token,
+        expires_at:    record.expires_at
+      })
+    end
+
+    def fetch_fresh_record
+      @last_token = @raw_token
+      @record.reload
+      @raw_token  = build_token
+    end
+
+    def token_changed?
+      @last_token.token != @raw_token.token
+    end
+
+    def determine_lock(lock)
+      case lock
+      when nil
+        Passthrough
+      when :redis
+        require "access_token_wrapper/redis_lock"
+        RedisLock.new([@record.class.to_s, @record.id].join("/"))
+      else
+        lock
+      end
+    end
+
+    module Passthrough
+      def self.lock
+        yield
+      end
+    end
+  end
+end

--- a/lib/access_token_wrapper/redis_lock.rb
+++ b/lib/access_token_wrapper/redis_lock.rb
@@ -1,0 +1,57 @@
+require 'redis'
+class RedisLock
+  class MultipleAccessError < StandardError; end
+  EXPIRE_AFTER_SECONDS = 35
+  RETRY_COUNT = 10
+  WAIT_INTERVAL_MS = 500
+  UNLOCK_SCRIPT='
+  if redis.call("get", KEYS[1]) == ARGV[1] then
+    return redis.call("del", KEYS[1])
+  else
+    return 0
+  end'
+
+  def initialize(key, expiry: EXPIRE_AFTER_SECONDS, redis_client: Redis.current, retry_count: RETRY_COUNT, wait_interval_ms: WAIT_INTERVAL_MS)
+    @key    = "redis-lock-#{key}"
+    @redis  = redis_client
+    @expiry = expiry
+    @wait_interval = wait_interval_ms / 1000.0
+    @retry_count   = retry_count
+  end
+
+  def lock(&block)
+    begin
+      retries ||= 0
+      single_lock(&block)
+    rescue MultipleAccessError
+      if (retries += 1) < @retry_count
+        sleep @wait_interval
+        retry
+      else
+        raise
+      end
+    end
+  end
+
+  def single_lock
+    lock_id = SecureRandom.base64(20)
+
+    if lock_mutex(@key, lock_id)
+      begin
+        yield
+      ensure
+        unlock_mutex(@key, lock_id)
+      end
+    else
+      raise MultipleAccessError
+    end
+  end
+
+  def lock_mutex(key, lock_id)
+    @redis.set(key, lock_id, nx: true, ex: @expiry)
+  end
+
+  def unlock_mutex(key, lock_id)
+    @redis.eval(UNLOCK_SCRIPT, [key], [lock_id])
+  end
+end

--- a/lib/access_token_wrapper/version.rb
+++ b/lib/access_token_wrapper/version.rb
@@ -1,3 +1,3 @@
 module AccessTokenWrapper
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end

--- a/test/from_record_test.rb
+++ b/test/from_record_test.rb
@@ -1,0 +1,215 @@
+require 'test_helper'
+
+class FromRecordTest < Minitest::Test
+  def described_class
+    AccessTokenWrapper::FromRecord
+  end
+
+  class FakeRecord
+    attr_reader :id, :reloaded
+    attr_accessor :access_token, :refresh_token, :expires_at
+    attr_writer :fresh_token
+
+    def initialize(access_token: 'ABC', refresh_token: 'DEF', expires_at: Time.now.to_i + 3600)
+      update_from_access_token(OpenStruct.new(token: access_token, refresh_token: refresh_token, expires_at: expires_at))
+      @id = 42
+      @fresh_token = nil
+    end
+
+    def update_from_access_token(token)
+      @access_token = token.token
+      @refresh_token = token.refresh_token
+      @expires_at = token.expires_at
+    end
+
+    def reload
+      @reloaded = true
+      if @fresh_token
+        update_from_access_token(@fresh_token)
+        @fresh_token = nil
+      end
+    end
+  end
+
+  class ExpiringFakeRecord < FakeRecord
+    def reload
+      @access_token  = access_token  + "*"
+      @refresh_token = refresh_token + "*"
+      @expires_at    = Time.now.to_i + 3600
+      super
+    end
+  end
+
+  def client
+    @client ||= OAuth2::Client.new('AAA', 'BBB', site: 'http://localhost:3000')
+  end
+
+  def setup
+    stub_request(:get, "http://localhost:3000/200").to_return(status: 200, body: "")
+    stub_request(:get, "http://localhost:3000/401").to_return({ status: 401, body: "" }, { status: 200, body: "" })
+    stub_request(:get, "http://localhost:3000/429").to_return(status: 429, body: "")
+  end
+
+  def stub_token_refresh
+    stub_request(:post, "http://localhost:3000/oauth/token").with(body: {"client_id"=>"AAA", "client_secret"=>"BBB", "grant_type"=>"refresh_token", "refresh_token"=>"DEF"}).to_return(status: 200, headers: { 'Content-Type' => 'application/json' }, body: token_response.to_json).times(1)
+  end
+
+  def stub_token_refresh_with_wait
+    stub_request(:post, "http://localhost:3000/oauth/token").to_return(status: 200, headers: { 'Content-Type' => 'application/json' }, body: lambda { |request| sleep 0.1; token_response.to_json }).times(1)
+  end
+
+  def token_response
+    {
+      "access_token": "57ed301af04bf35b40f255feb5ef469ab2f046aff14",
+      "expires_in": 7200,
+      "refresh_token": "026b343de07818b3ffebfb3001eff9a00aea43da0 ",
+      "scope": "public",
+      "token_type": "bearer"
+    }
+  end
+
+  def test_doesnt_run_block_if_no_exception
+    @run = false
+
+    token = described_class.new(client: client, record: FakeRecord.new) do |new_token, exception|
+      @run = true
+    end
+
+    token.get('/200')
+    assert !@run
+    assert !token.record.reloaded
+  end
+
+  def test_runs_refresh_block_if_exception
+    @run = false
+    stub_refresh = stub_token_refresh
+
+    token = described_class.new(client: client, record: FakeRecord.new) do |new_token, exception|
+      @run = true
+    end
+
+    token.get('/401')
+    assert @run
+    assert token.record.reloaded
+    assert_requested(stub_refresh)
+  end
+
+  def test_runs_refresh_block_if_expiring
+    @run = false
+    stub_refresh = stub_token_refresh
+    token = described_class.new(client: client, record: FakeRecord.new(expires_at: Time.now.to_i - 1)) do |new_token, exception|
+      @run = true
+    end
+
+    token.get('/200')
+    assert @run
+    assert token.record.reloaded
+    assert_requested(stub_refresh)
+  end
+
+  def test_doesnt_run_block_if_non_auth_exception
+    @run = false
+
+    token = described_class.new(client: client, record: FakeRecord.new) do |new_token, exception|
+      @run = true
+    end
+
+    begin
+      token.get('/429')
+    rescue OAuth2::Error
+    end
+
+    assert !@run
+    assert !token.record.reloaded
+  end
+
+  def test_refreshes_record_and_halts_api_request_if_not_needed
+    @run = false
+    stub_refresh = stub_token_refresh
+
+    token = described_class.new(client: client, record: ExpiringFakeRecord.new) do |new_token, exception|
+      @run = true
+    end
+
+    token.get('/401')
+
+    assert @run
+    assert_not_requested(stub_refresh)
+    assert token.record.reloaded
+  end
+
+  def test_runs_provided_lock_object
+    stub_refresh = stub_token_refresh
+
+    @run = false
+    lock = Module.new do
+      def self.lock
+        @prelock = true
+        yield
+        @postlock = true
+      end
+
+      def self.prelock
+        @prelock
+      end
+
+      def self.postlock
+        @postlock
+      end
+    end
+
+    token = described_class.new(client: client, record: FakeRecord.new, lock: lock) do |new_token, exception|
+      @run = true
+    end
+
+    token.get('/401')
+
+    assert @run
+    assert_requested(stub_refresh)
+
+    assert lock.prelock
+    assert lock.postlock
+  end
+
+  def test_that_the_redis_lock_locks
+    token = described_class.new(client: client, record: FakeRecord.new, lock: :redis) do |new_token, exception|
+      @run = true
+    end
+
+    assert token.instance_variable_get(:@lock).is_a?(RedisLock)
+  end
+
+  def test_that_the_lock_locks_multiple_requests
+    @results = []
+    record      = FakeRecord.new(expires_at: Time.now.to_i-1)
+    record_copy = FakeRecord.new(expires_at: Time.now.to_i-1)
+
+    token = described_class.new(client: client, record: record, lock: :redis) do |new_token, exception|
+      record.update_from_access_token(new_token)
+      record_copy.fresh_token = new_token
+      @run = true
+    end
+
+    token2 = described_class.new(client: client, record: record_copy, lock: :redis) do |new_token, exception|
+      @run = true
+    end
+
+    stub_refresh = stub_token_refresh_with_wait
+
+    new_thread = Thread.new do
+      @results << :before_primary
+      token.get('/200')
+      @results << :after_primary
+    end
+
+    sleep 0.01
+
+    @results << :before_secondary
+    token2.get('/200')
+    @results << :after_secondary
+
+    new_thread.join
+    assert_equal [:before_primary, :before_secondary, :after_primary, :after_secondary], @results
+    assert_requested(stub_refresh)
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,4 @@
 require 'minitest/autorun'
 require 'access_token_wrapper'
 require 'oauth2'
+require 'webmock/minitest'


### PR DESCRIPTION
**N.B:** This was fun, but I'm not sure if it's actually needed, I'm not seeing errors in Honeybadger, Doorkeeper's logic of reissuing tokens may actually have solved this problem a year ago.





This replaces the original Base module with a more comprehensive solution.

At it's core it uses a lock object (a Redis-based one is included) to wrap the refreshing of an access token so that multiple simultaneous requests with an expired access token don't get data out of sync.

- Request is made
- Wrapper either sees that the token is expired or receives the 401
- Wrapper acquires a lock specific to that API login (if lock is unavailable, it will retry 10 times over a 5 second period, numbers may need tweaking, if it fails after all that the MultipleAccess exception will be thrown)
- Wrapper reloads the record from the DB in case the access_Token has been refreshed in another simultaneous just finished request.
- If a newly refreshed token is available it drops out and makes the API request.
- If token has not been updated, then refresh the token
- Fires the callback (regardless of whether the token has been updated, not sure about this)
- Releases the lock and makes the API request
  