### PR TITLE
[FEATURE] Use expires_at attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,6 @@
+## 0.2.0 (2018-01-02)
+- [FEATURE] The library now checks the expires_at date of the token before attempting an API call.
+- [BREAKING] The refresh callback now only optionally contains an exception, when an exception is raised, if the refresh is due to the expires_at field (which should be the majority of the time) it will be `nil`
+
 ## 0.1.0 (2017-09-20)
 - [BREAKING] `AccessTokenWrapper::Base#token` was renamed to `#raw_token`.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,34 @@
+PATH
+  remote: .
+  specs:
+    access_token_wrapper (0.2.0)
+      oauth2
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    faraday (0.12.2)
+      multipart-post (>= 1.2, < 3)
+    jwt (1.5.6)
+    multi_json (1.12.2)
+    multi_xml (0.6.0)
+    multipart-post (2.0.0)
+    oauth2 (1.4.0)
+      faraday (>= 0.8, < 0.13)
+      jwt (~> 1.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 3)
+    rack (2.0.3)
+    rake (12.3.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  access_token_wrapper!
+  bundler (~> 1.3)
+  rake
+
+BUNDLED WITH
+   1.16.1

--- a/lib/access_token_wrapper/base.rb
+++ b/lib/access_token_wrapper/base.rb
@@ -1,6 +1,7 @@
 module AccessTokenWrapper
   class Base
     NON_ERROR_CODES = [402, 404, 422, 414, 429, 500, 503]
+    EXPIRY_GRACE_SEC = 30
     attr_reader :raw_token
 
     def initialize(raw_token, &callback)
@@ -9,6 +10,7 @@ module AccessTokenWrapper
     end
 
     def method_missing(method_name, *args, &block)
+      refresh_token! if token_expiring?
       @raw_token.send(method_name, *args, &block)
     rescue OAuth2::Error => exception
       if NON_ERROR_CODES.include?(exception.response.status)
@@ -19,9 +21,13 @@ module AccessTokenWrapper
       end
     end
 
-    def refresh_token!(exception)
+    def refresh_token!(exception = nil)
       @raw_token = @raw_token.refresh!
       @callback.call(@raw_token, exception)
+    end
+
+    def token_expiring?
+      @raw_token.expires_at < (Time.now.to_i + EXPIRY_GRACE_SEC)
     end
 
     def respond_to_missing?(method_name, include_private = false)

--- a/lib/access_token_wrapper/version.rb
+++ b/lib/access_token_wrapper/version.rb
@@ -1,3 +1,3 @@
 module AccessTokenWrapper
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
Previously this library (which proxies the OAuth token to automatically refresh OAuth tokens and is used in all our API apps) would always attempt the API request, and on receiving a 401 (Token expired) error would refresh the token and then retry the request.

This is very safe, but in every case we actually know when the token expires locally, so this PR changes the logic to firstly check if the token is expired (or expiring within 30s) and if so just refresh the token without making the API call which we already know is going to return a 401.

None of the original logic is removed, so at worst it falls back to the previous logic