### PR TITLE
[FEATURE] AccessTokenWrapper::FromRecord module. This replaces the original Base module with a more comprehensive solution.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+- [FEATURE] Adds in AccessTokenWrapper::FromRecord as an alternative refresh wrapper that uses ActiveRecord locking to remove race-conditions
+
 ## 0.2.1 (2018-01-23)
 - [BUGFIX] Allow the request to fallback to the old style if no expires_at provided
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,8 +7,13 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
+    hashdiff (1.0.1)
     jwt (2.2.1)
     multi_json (1.14.1)
     multi_xml (0.6.0)
@@ -19,8 +24,14 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
+    public_suffix (4.0.5)
     rack (2.2.2)
     rake (13.0.1)
+    safe_yaml (1.0.5)
+    webmock (3.8.3)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
   ruby
@@ -28,6 +39,7 @@ PLATFORMS
 DEPENDENCIES
   access_token_wrapper!
   rake
+  webmock
 
 BUNDLED WITH
    2.1.4

--- a/README.md
+++ b/README.md
@@ -43,8 +43,21 @@ def update_user_from_access_token(new_token)
 end
 ```
 
-## Note
-The `AccessTokenWrapper#token` is replaced with `AccessTokenWrapper#raw_token`
+or 
+
+```ruby
+def access_token
+  @access_token ||= begin
+    token = OAuth2::AccessToken.new(oauth_client, @user.access_token,
+            refresh_token: @user.refresh_token,
+            expires_at:    @user.expires_at
+    )
+    AccessTokenWrapper::FromRecord.new(client: oauth_client, record: @user) do |new_token, exception|
+      update_user_from_access_token(new_token)
+    end
+  end
+end
+```
 
 ## Contributing
 

--- a/access_token_wrapper.gemspec
+++ b/access_token_wrapper.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "webmock"
 
   spec.add_dependency "oauth2"
 end

--- a/lib/access_token_wrapper.rb
+++ b/lib/access_token_wrapper.rb
@@ -1,1 +1,2 @@
 require "access_token_wrapper/base"
+require "access_token_wrapper/from_record"

--- a/lib/access_token_wrapper/from_record.rb
+++ b/lib/access_token_wrapper/from_record.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module AccessTokenWrapper
+  class FromRecord < Base
+    attr_reader :record
+
+    # This is the core functionality
+    #
+    # @example
+    #   AccessTokenWrapper::FromRecord.new(client: client, record: user) do |new_token, exception|
+    #     update_user_from_access_token(new_token)
+    #   end
+    #
+    # @param [<OAuth2::Client>] client An instance of an OAuth2::Client object
+    # @param [<Object>] record An AR-like object that responds to `access_token`,
+    #   `refresh_token`, `expires_at`, `with_lock` and `reload`.
+    # @param [&block] callback A callback that gets called when a token is refreshed,
+    #   the callback is provided `new_token` and optional `exception` parameters
+    #
+    # @return <AccessTokenWrapper::FromRecord>
+    #
+    # @api public
+    def initialize(client:, record:, &callback)
+      @oauth_client = client
+      @record       = record
+      super(build_token, &callback)
+    end
+
+  private
+
+    # Override the refresh_token! method from the Base class to extend with locking logic
+    def refresh_token!(exception = nil)
+      @record.with_lock do
+        fetch_fresh_record
+
+        if token_requires_refresh?
+          @raw_token = @raw_token.refresh!
+          @callback.call(@raw_token, exception)
+        end
+      end
+    end
+
+    def build_token
+      OAuth2::AccessToken.new(@oauth_client, record.access_token, {
+        refresh_token: record.refresh_token,
+        expires_at:    record.expires_at
+      })
+    end
+
+    def fetch_fresh_record
+      @last_token = @raw_token
+      @record.reload
+      @raw_token = build_token
+    end
+
+    def token_requires_refresh?
+      @last_token.token == @raw_token.token
+    end
+  end
+end

--- a/test/from_record_test.rb
+++ b/test/from_record_test.rb
@@ -1,0 +1,187 @@
+require 'test_helper'
+
+class FromRecordTest < Minitest::Test
+  def described_class
+    AccessTokenWrapper::FromRecord
+  end
+
+  class FakeRecord
+    class << self
+      attr_accessor :locked
+    end
+
+    attr_reader :id, :reloaded
+    attr_accessor :access_token, :refresh_token, :expires_at
+    attr_writer :fresh_token
+
+    def initialize(access_token: 'ABC', refresh_token: 'DEF', expires_at: Time.now.to_i + 3600)
+      update_from_access_token(OpenStruct.new(token: access_token, refresh_token: refresh_token, expires_at: expires_at))
+      @id = 42
+      @fresh_token = nil
+    end
+
+    def update_from_access_token(token)
+      @access_token = token.token
+      @refresh_token = token.refresh_token
+      @expires_at = token.expires_at
+    end
+
+    def reload
+      @reloaded = true
+      if @fresh_token
+        update_from_access_token(@fresh_token)
+        @fresh_token = nil
+      end
+    end
+
+    def with_lock
+      true while self.class.locked
+
+      self.class.locked = true
+      sleep 0.1
+      yield
+      self.class.locked = false
+    end
+  end
+
+  class ExpiringFakeRecord < FakeRecord
+    def reload
+      @access_token  = access_token  + "*"
+      @refresh_token = refresh_token + "*"
+      @expires_at    = Time.now.to_i + 3600
+      super
+    end
+  end
+
+  def client
+    @client ||= OAuth2::Client.new('AAA', 'BBB', site: 'http://localhost:3000')
+  end
+
+  def setup
+    stub_request(:get, "http://localhost:3000/200").to_return(status: 200, body: "")
+    stub_request(:get, "http://localhost:3000/401").to_return({ status: 401, body: "" }, { status: 200, body: "" })
+    stub_request(:get, "http://localhost:3000/429").to_return(status: 429, body: "")
+  end
+
+  def stub_token_refresh
+    stub_request(:post, "http://localhost:3000/oauth/token").with(body: {"client_id"=>"AAA", "client_secret"=>"BBB", "grant_type"=>"refresh_token", "refresh_token"=>"DEF"}).to_return(status: 200, headers: { 'Content-Type' => 'application/json' }, body: token_response.to_json).times(1)
+  end
+
+  def stub_token_refresh_with_wait
+    stub_request(:post, "http://localhost:3000/oauth/token").to_return(status: 200, headers: { 'Content-Type' => 'application/json' }, body: lambda { |request| sleep 0.1; token_response.to_json }).times(1)
+  end
+
+  def token_response
+    {
+      "access_token": "57ed301af04bf35b40f255feb5ef469ab2f046aff14",
+      "expires_in": 7200,
+      "refresh_token": "026b343de07818b3ffebfb3001eff9a00aea43da0 ",
+      "scope": "public",
+      "token_type": "bearer"
+    }
+  end
+
+  def test_doesnt_run_block_if_no_exception
+    @run = false
+
+    token = described_class.new(client: client, record: FakeRecord.new) do |new_token, exception|
+      @run = true
+    end
+
+    token.get('/200')
+    assert !@run
+    assert !token.record.reloaded
+  end
+
+  def test_runs_refresh_block_if_exception
+    @run = false
+    stub_refresh = stub_token_refresh
+
+    token = described_class.new(client: client, record: FakeRecord.new) do |new_token, exception|
+      @run = true
+    end
+
+    token.get('/401')
+    assert @run
+    assert token.record.reloaded
+    assert_requested(stub_refresh)
+  end
+
+  def test_runs_refresh_block_if_expiring
+    @run = false
+    stub_refresh = stub_token_refresh
+    token = described_class.new(client: client, record: FakeRecord.new(expires_at: Time.now.to_i - 1)) do |new_token, exception|
+      @run = true
+    end
+
+    token.get('/200')
+    assert @run
+    assert token.record.reloaded
+    assert_requested(stub_refresh)
+  end
+
+  def test_doesnt_run_block_if_non_auth_exception
+    @run = false
+
+    token = described_class.new(client: client, record: FakeRecord.new) do |new_token, exception|
+      @run = true
+    end
+
+    begin
+      token.get('/429')
+    rescue OAuth2::Error
+    end
+
+    assert !@run
+    assert !token.record.reloaded
+  end
+
+  def test_refreshes_record_and_halts_api_request_if_not_needed
+    @run = false
+    stub_refresh = stub_token_refresh
+
+    token = described_class.new(client: client, record: ExpiringFakeRecord.new) do |new_token, exception|
+      @run = true
+    end
+
+    token.get('/401')
+
+    assert !@run
+    assert_not_requested(stub_refresh)
+    assert token.record.reloaded
+  end
+
+  def test_that_the_lock_locks_multiple_requests
+    @results = []
+    record      = FakeRecord.new(expires_at: Time.now.to_i-1)
+    record_copy = FakeRecord.new(expires_at: Time.now.to_i-1)
+
+    token = described_class.new(client: client, record: record) do |new_token, exception|
+      record.update_from_access_token(new_token)
+      record_copy.fresh_token = new_token
+      @run = true
+    end
+
+    token2 = described_class.new(client: client, record: record_copy) do |new_token, exception|
+      @run = true
+    end
+
+    stub_refresh = stub_token_refresh_with_wait
+
+    new_thread = Thread.new do
+      @results << :before_primary
+      token.get('/200')
+      @results << :after_primary
+    end
+
+    sleep 0.01
+
+    @results << :before_secondary
+    token2.get('/200')
+    @results << :after_secondary
+
+    new_thread.join
+    assert_equal [:before_primary, :before_secondary, :after_primary, :after_secondary], @results
+    assert_requested(stub_refresh)
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,4 @@
 require 'minitest/autorun'
 require 'access_token_wrapper'
 require 'oauth2'
+require 'webmock/minitest'


### PR DESCRIPTION
At it's core it uses an AR lock to wrap the refreshing of an access token so that multiple simultaneous requests with an expired access token don't get data out of sync.

- Request is made
- Wrapper either sees that the token is expired or receives the 401
- Wrapper acquires a lock specific to that API login
- Wrapper reloads the record from the DB in case the access_token has been refreshed in another simultaneous just finished request.
- If a newly refreshed token is available it drops out and makes the API request.
- If token has not been updated, then refresh the token
- Fires the callback (regardless of whether the token has been updated, not sure about this)
- Releases the lock and makes the API request